### PR TITLE
De-bitrot after 6 years.

### DIFF
--- a/Language/CIL/Goto.hs
+++ b/Language/CIL/Goto.hs
@@ -76,9 +76,7 @@ reduce maxDepth callTrace a = case a of
   Break _ -> notSupported' a "break outside of loop or switch"
   Case _ _ _ -> notSupported' a "case outside of switch"
   Default _ _ -> notSupported' a "default outside of switch"
-  Switch cond stmt p -> do
-    after <- nextLabel
-    (cases, stmts) <- rewriteCases (Label after p) stmts
+  Switch cond stmt p -> notSupported' a "reduce of Switch is not supported."
   _ -> notSupported' a "statement for goto transform"
 
   {-
@@ -99,7 +97,3 @@ reduceWhile maxDepth callTrace after a = case a of
     c <- reduceWhile maxDepth callTrace after c
     return $ If a b c p
   a -> reduce maxDepth callTrace a
-
-rewriteCases :: Name -> [Stmt] -> ([(Expr, Name)], [Stmt])
-rewriteCases end [] = []
-

--- a/Language/CIL/Parse.hs
+++ b/Language/CIL/Parse.hs
@@ -29,7 +29,7 @@ cTranslUnit (CTranslUnit items _) = CCompound [] (map f items ++ [CBlockStmt cal
   callMain :: CStat
   callMain = CExpr (Just $ CCall (CVar (Ident "main" 0 none) none) [] none) none
   none :: NodeInfo
-  none = internalNode
+  none = undefNode
 
 -- | Name of identifier.
 name :: Ident -> Name

--- a/Language/CIL/Parse.hs
+++ b/Language/CIL/Parse.hs
@@ -22,9 +22,10 @@ parseCIL name code = case parseC code (initPos name) of
 cTranslUnit :: CTranslUnit -> CStat
 cTranslUnit (CTranslUnit items _) = CCompound [] (map f items ++ [CBlockStmt callMain]) none
   where
+  f :: CExternalDeclaration NodeInfo -> CCompoundBlockItem NodeInfo
   f (CDeclExt a) = CBlockDecl a
   f (CFDefExt a) = CNestedFunDef a
-  f a@(CAsmExt _) = notSupported a "inline assembly"
+  f a@(CAsmExt {}) = notSupported a "inline assembly"
   callMain :: CStat
   callMain = CExpr (Just $ CCall (CVar (Ident "main" 0 none) none) [] none) none
   none :: NodeInfo
@@ -232,4 +233,3 @@ cFunDef (CFunDef specs (CDeclr (Just (Ident name _ _)) (CFunDeclr (Right (args',
   args = [ (name, cDeclType decl) | decl@(CDecl _ [(Just (CDeclr (Just (Ident name _ _)) _ Nothing [] _), Nothing, Nothing)] _) <- args' ]
 cFunDef a = notSupported a "function"
 -- FunctionDecl Type Name [Type] Stmt Position
-

--- a/Language/CIL/Utils.hs
+++ b/Language/CIL/Utils.hs
@@ -24,5 +24,6 @@ notSupported' a m = err' a $ "not supported: " ++ m
 position :: Pos a => a -> String
 position a = f ++ ":" ++ show l ++ ":" ++ show c
   where
-  Position f l c = posOf a
+  (f,l,c) = (posFile p, posRow p, posColumn p)
+  p = posOf a
 

--- a/cil.cabal
+++ b/cil.cabal
@@ -24,8 +24,8 @@ library
     build-depends:
         base          >= 4.0     && < 5.0,
         bytestring    >= 0.9     && < 1.0,
-        mtl           >= 1.1.0   && < 1.2,
-        language-c    >= 0.3.2   && < 0.4
+        mtl           >= 1.1.0   && < 2.3,
+        language-c    >= 0.6     && < 0.7
 
     exposed-modules:
         Language.CIL,


### PR DESCRIPTION
Remove never-released broken code with type and parse errors.
New MTL versions are out.
New language-c is out with small changes.
Inferred types that require FlexibleContexts don't automatically imply the extension.

Any chance of a hackage release?